### PR TITLE
Add device alias to MQTT-topic

### DIFF
--- a/TODO
+++ b/TODO
@@ -4,8 +4,6 @@
 
 - Refine the custom AppArmor-policy (see
   [`📄 docker/README.md`](./docker/README.md#using-d-bus))
-- Add a device identifier to the `tc66c/` MQTT topic; this allows measurements
-  for multiple devices to be handled
 - Upgrade to Node.js 14 (require it in `📄 package.json` and update the Docker
   container)
 - Add support for additional architectures (`armhf` / `amd64`) to the Docker

--- a/docker/rootfs/etc/services.d/tc66c-mqtt/run
+++ b/docker/rootfs/etc/services.d/tc66c-mqtt/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv ash
 # shellcheck shell=ash
 
-set -euo pipefail
+set -eo pipefail
 
 export NODE_OPTIONS="--unhandled-rejections=strict"
 
@@ -13,12 +13,17 @@ if [ -n "$M_INTERVAL" ] ; then interval="yes" ; fi
 loglevel=""
 if [ -n "$LOG_LEVEL" ] ; then loglevel="yes" ; fi
 
+devicealias=""
+if [ -n "$DEVICE_ALIAS" ] ; then devicealias="yes" ; fi
+
 if [ -n "$PUID" ] && [ -n "$PGID" ] ; then
   exec s6-setuidgid "$PUID:$PGID" "$cmd" "$TC66C_BLE_MAC" "$MQTT_BROKER" \
     ${interval:+ --interval "$M_INTERVAL"} \
-    ${loglevel:+ --logLevel "$LOG_LEVEL"}
+    ${loglevel:+ --logLevel "$LOG_LEVEL"} \
+    ${devicealias:+ --deviceAlias "$DEVICE_ALIAS"}
 else
   exec "$cmd" "$TC66C_BLE_MAC" "$MQTT_BROKER" \
     ${interval:+ --interval "$M_INTERVAL"} \
-    ${loglevel:+ --logLevel "$LOG_LEVEL"}
+    ${loglevel:+ --logLevel "$LOG_LEVEL"} \
+    ${devicealias:+ --deviceAlias "$DEVICE_ALIAS"}
 fi

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "TC66C-MQTT bridge",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build:docker:local": "docker build -t tc66c-mqtt ."
   },
   "author": "Thijs Putman <thijs@sgraastra.net>",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Add a device alias to the MQTT-topic.

This changes the topic from `tc66c/#` to `tc66c/device_alias/#` and thus allows multiple units to report into the same MQTT-server/topic.

If no device alias is provided, the Bluetooth MAC address is used (lower-cased, with all colons replaced by underscores – `12_34_56_78_90_ab`).